### PR TITLE
chore: remove unnecessary terraform tooling

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -12,7 +12,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
-      - uses: terraform-linters/setup-tflint@90f302c255ef959cbfb4bd10581afecdb7ece3e6 # v4.1.1
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,15 +25,6 @@ repos:
       - id: commitlint
         stages: [ commit-msg ]
         additional_dependencies: [ '@commitlint/config-conventional' ]
-  - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.105.0
-    hooks:
-      - id: terraform_tflint
-      - id: terraform_fmt
-      - id: terraform_checkov
-        language: docker_image
-        entry: --tty bridgecrew/checkov:3.2.354 --config-file checkov.yaml
-        pass_filenames: false
   - repo: https://github.com/renovatebot/pre-commit-hooks
     rev: 41.173.1
     hooks:

--- a/checkov.yaml
+++ b/checkov.yaml
@@ -4,11 +4,9 @@ custom-tool-name: Checkov
 compact: true
 directory:
   - .
-download-external-modules: true
 evaluate-variables: true
-external-modules-download-path: .external_modules
 framework:
-  - - terraform,terraform_plan,yaml,json,github_configuration,github_actions
+  - - yaml,json,github_configuration,github_actions
 hard-fail-on: MEDIUM
 mask: [ ]
 quiet: true


### PR DESCRIPTION
## Summary
- Remove `pre-commit-terraform` hooks from `.pre-commit-config.yaml`
- Remove `setup-terraform` and `setup-tflint` steps from `.github/workflows/pre-commit.yaml`
- Remove terraform-related config from `checkov.yaml` (framework, download-external-modules, external-modules-download-path)

This repo has no `.tf` files, so terraform tooling adds unnecessary CI time and dependencies.